### PR TITLE
making half_n int

### DIFF
--- a/poibin.py
+++ b/poibin.py
@@ -130,7 +130,7 @@ class PoiBin:
         """
         chi = np.empty(self.n + 1, dtype=complex)
         chi[0] = 1
-        half_n = self.n / 2 + self.n % 2
+        half_n = int(self.n / 2 + self.n % 2)
         # set first half of chis:
         for i in range(1, half_n + 1):
             chi[i] = self.get_chi(i)


### PR DESCRIPTION
First off, great implementation of poisson binomial!  I'm building a system/algorithm/webapp (we'll see how ambitious I get) around the board game Settlers of Catan to quantify the "luck factor" (i.e. at turn X, a player has Y resources, what percentile are they are in?)... So i think the poisson binomial cdf is what I want.  I'm surprised how few implementations there are out there for what seems like a pretty common problem, so I've thoroughly enjoyed reading your poibin repo.

In any case - I might be missing something obvious, but with Python 3.5 (Anaconda 4.2.0), I needed to make the one little change in this PR to run your code.  

Without this change, this is the my error: 

```
import poibin
poibin.PoiBin([0.1, 0.2, 0.3])
```

```
Traceback (most recent call last):
  File "/Users/ajb/anaconda3/lib/python3.5/site-packages/IPython/core/interactiveshell.py", line 2881, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-18-de02896a678f>", line 1, in <module>
    poibin.PoiBin([0.1, 0.2, 0.3])
  File "/Users/ajb/Documents/github/poibin/poibin.py", line 55, in __init__
    self.pmf_list = self.get_pmf_xi()
  File "/Users/ajb/Documents/github/poibin/poibin.py", line 135, in get_pmf_xi
    for i in range(1, half_n + 1):
TypeError: 'float' object cannot be interpreted as an integer
```
