### PR TITLE
Solving FFT instability issues

### DIFF
--- a/poibin.py
+++ b/poibin.py
@@ -267,7 +267,7 @@ class PoiBin(object):
         :param xi_values: single event probabilities
         :type xi_values: complex
         """
-        return np.all(xi_values.imag <= np.finfo(float).eps)
+        return np.all(xi_values.imag <= 1e-15)
 
     def check_input_prob(self):
         """Check that all the input probabilities are in the interval [0, 1]."""


### PR DESCRIPTION
This PR addresses #4 

The error arises because of a check which in place to make sure that all the x_i values are real. This is done by the function `check_xi_are_real()` on line 261 of `poibin.py`. Due to instability in FFT, the imaginary parts don't turn out to be exactly 0. To ensure that these imaginary parts are indeed small, the following check has been placed in code:

`xi_values.imag <= np.finfo(float).eps`

On my machine, the value of `eps` turns out to be 2.220446049250313e-16

It turns out, this value is not enough to account for the instability in FFT. Increasing this slightly up to 1e-15 solves this problem.

I feel that making this change is a practical solution to the problem and will still not hurt accuracy.